### PR TITLE
Vendor `iterable-transform-replace`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "has-own-property": "^0.1.0",
     "identity-function": "^1.0.0",
     "iterable-lookahead": "^1.0.0",
-    "iterable-transform-replace": "^1.1.1",
     "lodash.curry": "^4.1.1",
     "magic-string": "^0.16.0",
     "map-iterable": "^1.0.1",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,4 @@
 exports.loggerPhase = require('./logger-phase');
 exports.tokens = require('./tokens');
 exports.isValidName = require('./is-valid-name');
-exports.replaceRule = require('iterable-transform-replace');
+exports.replaceRule = require('../vendored/iterable-transform-replace');

--- a/src/vendored/iterable-transform-replace.js
+++ b/src/vendored/iterable-transform-replace.js
@@ -1,0 +1,20 @@
+'use strict';
+const curry = require('lodash.curry');
+
+function replace(oldItem, newItem, array) {
+	return array.map(item => {
+		if (item === oldItem) {
+			return newItem;
+		}
+
+		return item;
+	});
+}
+
+module.exports = curry(replace);
+
+// This code was taken from:
+// - https://www.npmjs.com/package/iterable-transform-replace
+// - https://github.com/parro-it/iterable-transform-replace
+// which is available under the MIT license
+// It was modified to use lodash.curry instead of hughfdjackson's curry function


### PR DESCRIPTION
Vendor `iterable-transform-replace` to be able to replace the dependency on [hughfdjackson's `curry` package](https://www.npmjs.com/package/curry) by [lodash' `curry` package](https://www.npmjs.com/package/lodash.curry), similar to 1309108ad9f0f14bc89bb6bd251331f9b9030a2b.