### PR TITLE
Vendor `transform-spread-iterable`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "reverse-arguments": "^1.0.0",
     "shell-quote-word": "^1.0.1",
     "to-pascal-case": "^1.0.0",
-    "transform-spread-iterable": "^1.1.0",
     "unescape-js": "^1.0.5"
   }
 }

--- a/src/modes/bash/rules/alias-substitution.js
+++ b/src/modes/bash/rules/alias-substitution.js
@@ -4,7 +4,7 @@ const compose = require('compose-function');
 const identity = require('identity-function');
 const map = require('../../../vendored/map-iterable');
 const values = require('object-values');
-const merge = require('transform-spread-iterable');
+const merge = require('../../../vendored/transform-spread-iterable');
 const tokens = require('../../../utils/tokens');
 
 const expandAlias = (preAliasLexer, resolveAlias, reservedWords) => {

--- a/src/modes/posix/rules/alias-substitution.js
+++ b/src/modes/posix/rules/alias-substitution.js
@@ -3,7 +3,7 @@
 const compose = require('compose-function');
 const identity = require('identity-function');
 const map = require('../../../vendored/map-iterable');
-const merge = require('transform-spread-iterable');
+const merge = require('../../../vendored/transform-spread-iterable');
 const tokens = require('../../../utils/tokens');
 
 const expandAlias = (preAliasLexer, resolveAlias) => {

--- a/src/modes/posix/rules/field-splitting.js
+++ b/src/modes/posix/rules/field-splitting.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const map = require('../../../vendored/map-iterable');
-const merge = require('transform-spread-iterable');
+const merge = require('../../../vendored/transform-spread-iterable');
 const compose = require('compose-function');
 const mkFieldSplitToken = require('../../../utils/tokens').mkFieldSplitToken;
 

--- a/src/vendored/transform-spread-iterable.js
+++ b/src/vendored/transform-spread-iterable.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function * spread(source) {
+	for (const item of source) {
+		if (typeof item[Symbol.iterator] === 'function') {
+			yield* item;
+		} else {
+			yield item;
+		}
+	}
+}
+
+module.exports = spread;
+
+// This code was taken from:
+// - https://www.npmjs.com/package/transform-spread-iterable
+// - https://github.com/parro-it/transform-spread-iterable
+// which is available under the MIT license
+// It was vendored to avoid the (unnecessary) dependency on hughfdjackson's curry package


### PR DESCRIPTION
Vendor `transform-spread-iterable` to be able to remove the (unnecessary) dependency on [hughfdjackson's `curry` package](https://www.npmjs.com/package/curry), similar to 1309108ad9f0f14bc89bb6bd251331f9b9030a2b, 7dc6566c04ef1063ecb65313f209016202043353, and ef2505d05b08fe185e6c4d3f6b8111c5b1cf0038.