### PR TITLE
Vendor `filter-iterator`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "babylon": "^6.9.1",
     "compose-function": "^3.0.3",
     "deep-freeze": "0.0.1",
-    "filter-iterator": "0.0.1",
     "filter-obj": "^1.1.0",
     "has-own-property": "^0.1.0",
     "identity-function": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babylon": "^6.9.1",
     "compose-function": "^3.0.3",
     "deep-freeze": "0.0.1",
+    "filter-iterator": "0.0.1",
     "filter-obj": "^1.1.0",
     "has-own-property": "^0.1.0",
     "identity-function": "^1.0.0",
@@ -57,6 +58,7 @@
     "map-obj": "^2.0.0",
     "object-pairs": "^0.1.0",
     "object-values": "^1.0.0",
+    "reverse-arguments": "^1.0.0",
     "shell-quote-word": "^1.0.1",
     "to-pascal-case": "^1.0.0",
     "unescape-js": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "babylon": "^6.9.1",
     "compose-function": "^3.0.3",
     "deep-freeze": "0.0.1",
-    "filter-iterator": "0.0.1",
     "filter-obj": "^1.1.0",
     "has-own-property": "^0.1.0",
     "identity-function": "^1.0.0",
@@ -58,7 +57,6 @@
     "map-obj": "^2.0.0",
     "object-pairs": "^0.1.0",
     "object-values": "^1.0.0",
-    "reverse-arguments": "^1.0.0",
     "shell-quote-word": "^1.0.1",
     "to-pascal-case": "^1.0.0",
     "unescape-js": "^1.0.5"

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,8 +1,12 @@
 'use strict';
-const filterIterator = require('filter-iterator');
-const reverse = require('reverse-arguments');
 const curry = require('lodash.curry');
 
-const filter = curry(reverse(filterIterator), 2);
+function* filterIterator(pred, xs) {
+	for (const x of xs) {
+		if (pred(x)) yield x;
+	}
+}
+
+const filter = curry(filterIterator, 2);
 
 module.exports = filter;

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,12 +1,10 @@
 'use strict';
 const curry = require('lodash.curry');
 
-function* filterIterator(pred, xs) {
+function* filter(pred, xs) {
 	for (const x of xs) {
 		if (pred(x)) yield x;
 	}
 }
 
-const filter = curry(filterIterator, 2);
-
-module.exports = filter;
+module.exports = curry(filter, 2);

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,10 +1,12 @@
 'use strict';
 const curry = require('lodash.curry');
 
-function* filter(pred, xs) {
+function* filterIterator(pred, xs) {
 	for (const x of xs) {
 		if (pred(x)) yield x;
 	}
 }
 
-module.exports = curry(filter, 2);
+const filter = curry(filterIterator, 2);
+
+module.exports = filter;

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,12 +1,8 @@
 'use strict';
+const filterIterator = require('filter-iterator');
+const reverse = require('reverse-arguments');
 const curry = require('lodash.curry');
 
-function* filterIterator(pred, xs) {
-	for (const x of xs) {
-		if (pred(x)) yield x;
-	}
-}
-
-const filter = curry(filterIterator, 2);
+const filter = curry(reverse(filterIterator), 2);
 
 module.exports = filter;

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,5 +1,5 @@
 'use strict';
-const filterIterator = require('filter-iterator');
+const filterIterator = require('../vendored/filter-iterator');
 const reverse = require('reverse-arguments');
 const curry = require('lodash.curry');
 

--- a/src/vendored/filter-iterator.js
+++ b/src/vendored/filter-iterator.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = filterIterator;
+
+function* filterIterator(xs, pred) {
+  for (let x of xs) {
+    if (pred(x)) yield x;
+  }
+}
+
+// This code was taken from:
+// - https://www.npmjs.com/package/filter-iterator
+// - https://github.com/jb55/filter-iterator
+// which is available under the MIT license

--- a/src/vendored/filter-iterator.js
+++ b/src/vendored/filter-iterator.js
@@ -12,3 +12,5 @@ function* filterIterator(xs, pred) {
 // - https://www.npmjs.com/package/filter-iterator
 // - https://github.com/jb55/filter-iterator
 // which is available under the MIT license
+// It was vendored to avoid dependency on this package,
+// which does not declare its license in package.json


### PR DESCRIPTION
`filter-iterator` does not contain a license field in its `package.json`, which is a problem for automated license compatibility checkers. The PR with the fix has been open for over a year with no response: https://github.com/jb55/filter-iterator/pull/1